### PR TITLE
Team Member Roles written up 

### DIFF
--- a/docs/Common.tex
+++ b/docs/Common.tex
@@ -2,12 +2,12 @@
 
 \newcommand{\progname}{Software Engineering} % PUT YOUR PROGRAM NAME HERE
 \newcommand{\authname}{Team 16, Durum Wheat Semolina
-	\\ Alexander Moica, moicaa
-	\\ Yasmine Jolly, jollyy
-	\\ Jeffrey Wang, wangw115
-	\\ Jack Theriault, theriauj
-	\\ Catherine Chen, chenc134
-	\\ Justina Srebrnjak, srebrnjj } % AUTHOR NAMES                 
+	\\ Alexander Moica
+	\\ Yasmine Jolly
+	\\ Jeffrey Wang
+	\\ Jack Theriault
+	\\ Catherine Chen
+	\\ Justina Srebrnjak } % AUTHOR NAMES                 
 
 \usepackage{hyperref}
     \hypersetup{colorlinks=true, linkcolor=blue, citecolor=blue, filecolor=blue,

--- a/docs/DevelopmentPlan/DevelopmentPlan.tex
+++ b/docs/DevelopmentPlan/DevelopmentPlan.tex
@@ -39,6 +39,50 @@ Date2 & Name(s) & Description of changes\\
 
 \section{Team Member Roles}
 
+Utrition will not contain a team leader. Team members will have equal authority and influence on major decisions and plans for the project. All important decisions must be unanimously agreed upon by all team members.
+
+Each team member is expected to contribute to both technical developement and written documentation work during this project. Tasks will be distributed throughout the span of the project where each group member is responsible for their assigned work. In addition to these responsibilities, specific roles have been assigned to each member to ensure organization of the project and high quality deliverables. These roles are discussed below. 
+
+\subsection{Alexander Moica}
+
+\begin{itemize}
+	\item Backend Developer Lead: responsible for leading development of backend implementation. All needed work for product functionality must be identified and managed by this role. Questions regarding backend work will be directed to this role.
+	\item Github Specialist: responsible for managing the project on Github including creating Git issues and managing tags. Additionally, any questions about Github functionality will be directed to this role.
+\end{itemize}
+
+\subsection{Yasmine Jolly}
+
+\begin{itemize}
+	\item Meeting Chair: responsible for creating meeting agendas and leading all meetings. This role ensures meetings stay on track with minimal distractions and all meeting items are discussed. 
+	\item Scribe: responsible for documenting notable discussions and decisions that arise during group meetings.
+\end{itemize}
+
+\subsection{Jeffrey Wang}
+
+\begin{itemize}
+	\item Team Liaison: responsible for communicating questions and concerns on behalf of the team to the class instructor and/or teaching assistants. 
+	\item LaTeX Specialist: responsible for answering all team internal questions related to LaTeX. 
+\end{itemize}
+
+\subsection{Jack Theriault}
+
+\begin{itemize}
+	\item Testing Lead: responsible for leading testing processes and ensuring other team members are creating complete test cases for their code. Final testing efforts will be done by this role.
+\end{itemize}
+
+\subsection{Catherine Chen}
+
+\begin{itemize}
+	\item Frontend Developer Lead: responsible for leading development of frontend implementation. All needed work for user interface implementation and design must be identified and managed by this role. Questions regarding frontend work will be directed to this role.
+	\item Meeting Room Booker: responsible for booking private study rooms on McMaster University's campus for team meetings. This role will book a room and notify all team members 24 hours before the scheduled meeting.
+\end{itemize}
+
+\subsection{Justina Srebrnjak}
+
+\begin{itemize}
+	\item Documentation Proof Reader: responsible for reviewing all documentation. This includes ensuring the document is cohesive, correcting any grammar or spelling errors, and grading the document with provided rubics before submission.   
+\end{itemize}
+
 \section{Workflow Plan}
 
 \begin{itemize}


### PR DESCRIPTION
### What problem does this solve?
Team Member Roles in Dev. Plan has been written. Additionally author names in Common.tex has been modified to remove macIDs as per Dr. Smith's request in lecture.

Fixes #17 

Context: _provide context here_

### How does this solve it?
_Solution description_
Paragraphs written about each team member and their roles in the project.

### QA
_Quality assurance that was done for this code_
