### PR TITLE
Rev1 - VoiceUpload - Reset/Submit now clears text 

### DIFF
--- a/src/utrition/src/components/voiceupload/voiceupload.js
+++ b/src/utrition/src/components/voiceupload/voiceupload.js
@@ -4,6 +4,7 @@ import useSpeechToText from "react-hook-speech-to-text";
 
 const VoiceUpload = () => {
   const [responseData, setResponseData] = useState("");
+  const [softReset, forceSoftReset] = useState(true);
 
   const {
     error,
@@ -17,8 +18,9 @@ const VoiceUpload = () => {
     useLegacyResults: false,
   });
 
-  const reset = () => {
-    window.location.reload(false);
+  function reset() {
+    results.splice(0, results.length);
+    forceSoftReset(!softReset);
   };
 
   function voice_submit() {
@@ -30,7 +32,7 @@ const VoiceUpload = () => {
       upload_type: "voice",
       food_text: transcript,
     };
-
+    results.splice(0, results.length);
     axios({
       method: "GET",
       headers: headers,


### PR DESCRIPTION
### What problem does this solve?

Context: Previously, when the user pressed refresh on the voice upload, they would have their page refreshed, and they would be taken back to the TextUpload.

A secondary problem: Upon submitting some voice input, the input would not be cleared, allowing the user to accidentally submit the previous input again.

### How does this solve it?
Now, a state variable has been added to soft-refresh the page whenever reset/submission is executed. This clears whatever the user had previously inputted.