### PR TITLE
Rev1 - VoiceUpload - Stopping recording upon switching upload component

### DIFF
--- a/src/utrition/src/components/voiceupload/voiceupload.js
+++ b/src/utrition/src/components/voiceupload/voiceupload.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import axios from "axios";
 import useSpeechToText from "react-hook-speech-to-text";
 
@@ -17,6 +17,12 @@ const VoiceUpload = () => {
     continuous: true,
     useLegacyResults: false,
   });
+
+  useEffect(() => {
+    return () => {
+        stopSpeechToText()
+    }
+  })
 
   function reset() {
     results.splice(0, results.length);


### PR DESCRIPTION
### What problem does this solve?

Context: Previously, voiceupload would continue to record when user switched to another component, furthermore, there was a bug which prevented users from starting the recording upon switching.

### How does this solve it?
A useEffect has been added to stop the recording every time an upload component is destroyed.
